### PR TITLE
Atomic rdo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ensime
+.idea
 
 log
 target

--- a/src/main/scala/rover/rdo/ObjectState.scala
+++ b/src/main/scala/rover/rdo/ObjectState.scala
@@ -1,37 +1,64 @@
-
-package rover.rdo {
-	import scala.Predef
-
+package rover.rdo
+//{
+	
 	trait ObjectState {
-
+	
 	}
-
-	abstract class AtomicObjectState[T <: Op[_ <: AtomicObjectState[T]]] extends ObjectState {
+	
+	abstract class AtomicObjectState[A <: AtomicObjectState[A]] extends ObjectState {
+		// binding this to a self-type A
+		this: A =>
+		
 		// not sure due to types... do we want the _specific_ subtype here? Not the abstract state
-		private var ops: List[T] = List()
-
-		protected def applyOp(operation: T): Unit = {
+		private var ops: List[Op] = List()
+		
+		type Op = A => A
+//		type Op = AtomicObjectState => AtomicObjectState
+		
+		def applyOp(operation: Op): A = {
 			// Let the operation apply itself on the state
-//			operation.
-			operation.applyOn(this)
+			//			operation.
+			val result = operation.apply(this)
 
 			// Record the operation in the "log" or "event stream" of operations
 			this.ops = this.ops :+ operation
+
+			return result
 		}
-
 	}
+//}
+	
 
-	// framework
-	abstract class Op[T <: AtomicObjectState[_ <: Op[T]]] {
-		/**
-		  * <p>Applies the operation on the state, must return the new, modified state</p>
-		  * <p><b>WARNING: DO NOT USE THIS DIRECTLY!
-		  *     Only AtomicObjectState should use this method.
-		  *     Couldn't lock this down properly, perhaps some day
-		  * </b></p>
-		  * @param state
-		  * @return
-		  */
-		private[rdo] def applyOn(state: T): T
-	}
-}
+	
+//	abstract class Op[AbstractObjectState] {
+//		/**
+//		  * <p>Applies the operation on the state, must return the new, modified state
+//		  *
+//		  * <p><p>
+//		  * <b>WARNING: DO NOT USE THIS DIRECTLY!
+//		  *     Only AtomicObjectState should use this method.
+//		  * </b>
+//		  * @param state
+//		  * @return
+//		  */
+//		private[rdo] def applyOn(state: T): T
+//	}
+
+// framework
+//abstract class Op[T <: AtomicObjectState] {
+//	/**
+//	  * <p>Applies the operation on the state, must return the new, modified state
+//	  *
+//	  * <p><p>
+//	  * <b>WARNING: DO NOT USE THIS DIRECTLY!
+//	  *     Only AtomicObjectState should use this method.
+//	  * </b>
+//	  * @param state
+//	  * @return
+//	  */
+//	private[rdo] def applyOn(state: T): T
+//}
+
+//
+//	abstract class
+//}

--- a/src/main/scala/rover/rdo/ObjectState.scala
+++ b/src/main/scala/rover/rdo/ObjectState.scala
@@ -1,29 +1,37 @@
-package rover.rdo
 
-import votingapp.{PollChoice, Votes}
+package rover.rdo {
+	import scala.Predef
 
-trait ObjectState {
+	trait ObjectState {
 
-}
-
-class AtomicObjectState extends ObjectState {
-	// not sure due to types... do we want the _specific_ subtype here? Not the abstract state
-	private var ops: List[Op[AtomicObjectState]] = List()
-
-	protected def apply(operation: Op[AtomicObjectState]) = {
-		operation.applyOn(this)
-		this.ops = this.ops :+ operation
 	}
-}
 
-// framework
-trait Op[ObjectState] {
-	def applyOn(state: ObjectState): ObjectState
-}
+	abstract class AtomicObjectState[T <: Op[_ <: AtomicObjectState[T]]] extends ObjectState {
+		// not sure due to types... do we want the _specific_ subtype here? Not the abstract state
+		private var ops: List[T] = List()
 
-// app code
-class CastVoteOp(private val vote: PollChoice) extends Op[Votes] {
-	override def applyOn(state: Votes): Votes = {
-		return state.add(vote)
+		protected def applyOp(operation: T): Unit = {
+			// Let the operation apply itself on the state
+//			operation.
+			operation.applyOn(this)
+
+			// Record the operation in the "log" or "event stream" of operations
+			this.ops = this.ops :+ operation
+		}
+
+	}
+
+	// framework
+	abstract class Op[T <: AtomicObjectState[_ <: Op[T]]] {
+		/**
+		  * <p>Applies the operation on the state, must return the new, modified state</p>
+		  * <p><b>WARNING: DO NOT USE THIS DIRECTLY!
+		  *     Only AtomicObjectState should use this method.
+		  *     Couldn't lock this down properly, perhaps some day
+		  * </b></p>
+		  * @param state
+		  * @return
+		  */
+		private[rdo] def applyOn(state: T): T
 	}
 }

--- a/src/main/scala/rover/rdo/ObjectState.scala
+++ b/src/main/scala/rover/rdo/ObjectState.scala
@@ -1,64 +1,26 @@
 package rover.rdo
-//{
 	
-	trait ObjectState {
+trait ObjectState {
+
+}
+
+abstract class AtomicObjectState[A <: AtomicObjectState[A]] extends ObjectState {
+	// binding this to a self-type A
+	this: A =>
 	
+	// not sure due to types... do we want the _specific_ subtype here? Not the abstract state
+	private var ops: List[Op] = List()
+	
+	type Op = A => A
+	
+	def applyOp(operation: Op): A = {
+		// Let the operation apply itself on the state
+		//			operation.
+		val result = operation.apply(this)
+
+		// Record the operation in the "log" or "event stream" of operations
+		this.ops = this.ops :+ operation
+
+		return result
 	}
-	
-	abstract class AtomicObjectState[A <: AtomicObjectState[A]] extends ObjectState {
-		// binding this to a self-type A
-		this: A =>
-		
-		// not sure due to types... do we want the _specific_ subtype here? Not the abstract state
-		private var ops: List[Op] = List()
-		
-		type Op = A => A
-//		type Op = AtomicObjectState => AtomicObjectState
-		
-		def applyOp(operation: Op): A = {
-			// Let the operation apply itself on the state
-			//			operation.
-			val result = operation.apply(this)
-
-			// Record the operation in the "log" or "event stream" of operations
-			this.ops = this.ops :+ operation
-
-			return result
-		}
-	}
-//}
-	
-
-	
-//	abstract class Op[AbstractObjectState] {
-//		/**
-//		  * <p>Applies the operation on the state, must return the new, modified state
-//		  *
-//		  * <p><p>
-//		  * <b>WARNING: DO NOT USE THIS DIRECTLY!
-//		  *     Only AtomicObjectState should use this method.
-//		  * </b>
-//		  * @param state
-//		  * @return
-//		  */
-//		private[rdo] def applyOn(state: T): T
-//	}
-
-// framework
-//abstract class Op[T <: AtomicObjectState] {
-//	/**
-//	  * <p>Applies the operation on the state, must return the new, modified state
-//	  *
-//	  * <p><p>
-//	  * <b>WARNING: DO NOT USE THIS DIRECTLY!
-//	  *     Only AtomicObjectState should use this method.
-//	  * </b>
-//	  * @param state
-//	  * @return
-//	  */
-//	private[rdo] def applyOn(state: T): T
-//}
-
-//
-//	abstract class
-//}
+}

--- a/src/main/scala/rover/rdo/client/RdObject.scala
+++ b/src/main/scala/rover/rdo/client/RdObject.scala
@@ -26,7 +26,7 @@ trait RdObject {
   * @param one Some RDO
   * @param other Some other RDO
   */
-class CommonAncestor[RDO <: RdObject](one: RDO, other: RDO) extends RdObject {
+class CommonAncestor[RDO <: RdObject](private val one: RDO, private val other: RDO) extends RdObject {
 
 	// determine it once and defer all RdObject methods to it
 	private val commonAncestor: RDO = {

--- a/src/main/scala/votingapp/Poll.scala
+++ b/src/main/scala/votingapp/Poll.scala
@@ -29,11 +29,7 @@ class Votes(val asMap: Map[PollChoice, Int]) extends AtomicObjectState[Votes] {
 	  * @return New state with the vote added
 	  */
 	def add(vote: PollChoice): Votes = {
-		
 		return applyOp(new CastVoteOp(vote))
-		
-//		return this
-//		new CastVoteOp(vote).applyOn(this)
 	}
 
 	def majorityChoice: PollChoice = {

--- a/src/main/scala/votingapp/Poll.scala
+++ b/src/main/scala/votingapp/Poll.scala
@@ -1,6 +1,6 @@
 package votingapp
 
-import rover.rdo.{AtomicObjectState, ObjectState, Op}
+import rover.rdo.AtomicObjectState
 
 class Poll(val question: String, val choices: List[PollChoice]) {
 	var votes: Votes = Votes(choices)
@@ -22,15 +22,17 @@ class PollResult(private  val votes: Votes) {
 
 case class PollChoice(choice: String)
 
-class Votes(val asMap: Map[PollChoice, Int]) extends AtomicObjectState[Op[Votes]] {
+class Votes(val asMap: Map[PollChoice, Int]) extends AtomicObjectState[Votes] {
 	/**
 	  * Adds the given poll choice to the votes cast. Also: immutable object pattern.
 	  * @param vote The vote-choice to cast
 	  * @return New state with the vote added
 	  */
 	def add(vote: PollChoice): Votes = {
-		applyOp(new CastVoteOp(vote))
-		return this
+		
+		return applyOp(new CastVoteOp(vote))
+		
+//		return this
 //		new CastVoteOp(vote).applyOn(this)
 	}
 
@@ -56,11 +58,11 @@ object Votes {
 	}
 }
 
-trait VoteOp extends Op[Votes]
+//trait VoteOp extends AtomicObjectState#Op
 
 // app code
-class CastVoteOp(private val vote: PollChoice) extends VoteOp {
-	final override def applyOn(state: Votes): Votes = {
+class CastVoteOp(private val vote: PollChoice) extends Votes#Op {
+	final override def apply(state: Votes): Votes = {
 		if (state.asMap contains vote) {
 			Votes(state.asMap updated (vote, state.asMap(vote) + 1))
 		}


### PR DESCRIPTION
A working approach towards a framework-like inversion of control for atomizing state change operations.

The implementing "stateful" object extends AtomicObjectState and each state-modifying method must be implemented as an `Op` (Operation) for that object state, the operation can then be executed by giving it to the protected `applyOp` method. An example implementation can be seen in `votingapp.Poll.Votes#add` method.

There is however one major issue: the `applyOp` returns a new, resulting State. Thus a method on the application-state-implementation that might consist of multiple ops, would have to chain on the state object returned by the `applyOp`, not on `this`. Example:

```scala
def someMethod(data: Any): SomeState = {
    applyOp(new SomeOp1())
    applyOp(new SomeOp2()) // Wrong!
}
```

However, this might be mitigated a bit due to the fact that the new, resulting state must be returned. Making the developer think a little bit better about what he's doing. Except, scala returns whatever the last expression resulted in thus hiding such bad use of `applyOp` error from the compiler...


Correct:
```scala
def someMethod(data: Any): SomeState = {
    applyOp(new SomeOp1())
        .applyOp(new SomeOp2()) // note the dot
}
```

or:
```scala
def someMethod(data: Any): SomeState = {
    val resultOp1 = applyOp(new SomeOp1())
    result.applyOp(new SomeOp2())
}
```