### PR TITLE
Common ancestor log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .ensime
 .idea
 .gradle
+out
 
 *.jar
 *.iml

--- a/src/main/scala/chatapp/Chat.scala
+++ b/src/main/scala/chatapp/Chat.scala
@@ -39,10 +39,10 @@ class Chat(var messages: List[ChatMessage]) extends RdObject[String](new AtomicO
 		messages.size
 	}
 
-	override def stableVersion: Long = {
-		// TODO: the stable version (last committed)
-		messages.size
-	}
+//	override def stableVersion: Long = {
+//		// TODO: the stable version (last committed)
+//		messages.size
+//	}
 
 	def printMessages(): Unit = {
 		for (i <- messages) {

--- a/src/main/scala/chatapp/Chat.scala
+++ b/src/main/scala/chatapp/Chat.scala
@@ -5,7 +5,7 @@ import rover.rdo.client.RdObject
 
 // FIXME: ensure messages can be read, but not modified or reassigned...
 // FIXME: after state & rd object impl change
-class Chat(var messages: List[ChatMessage]) extends RdObject[String](new AtomicObjectState[String]("ss")) {
+class Chat(var messages: List[ChatMessage]) extends RdObject[String](AtomicObjectState.initial("")) {
 
 	// TODO: Something with users, crypto stuff on identity
 	// FIXME: Hashes should be used here as well as user ids
@@ -35,7 +35,7 @@ class Chat(var messages: List[ChatMessage]) extends RdObject[String](new AtomicO
 		//TODO: terminate
 	}
 
-	override def currentVersion(): Long = {
+	def currentVersion(): Long = {
 		messages.size
 	}
 

--- a/src/main/scala/chatapp/Chat.scala
+++ b/src/main/scala/chatapp/Chat.scala
@@ -1,9 +1,11 @@
 package chatapp
 
+import rover.rdo.AtomicObjectState
 import rover.rdo.client.RdObject
 
 // FIXME: ensure messages can be read, but not modified or reassigned...
-class Chat(var messages: List[ChatMessage]) extends RdObject {
+// FIXME: after state & rd object impl change
+class Chat(var messages: List[ChatMessage]) extends RdObject[String](new AtomicObjectState[String]("ss")) {
 
 	// TODO: Something with users, crypto stuff on identity
 	// FIXME: Hashes should be used here as well as user ids

--- a/src/main/scala/rover/rdo/AtomicObjectState.scala
+++ b/src/main/scala/rover/rdo/AtomicObjectState.scala
@@ -1,27 +1,54 @@
 package rover.rdo
 
-import rover.rdo.client.LogRecord
+import rover.rdo.client.{Log, LogRecord}
 
-class AtomicObjectState[A](private var value: A) extends ObjectState {
-	// Initialization of the record with the current state and empyt list of ops
-	private val record: LogRecord[A] = new LogRecord[A](List(value))
+// TODO: make ctor private
+class AtomicObjectState[A](private val value: A, private[rdo] val log: Log[A]) extends ObjectState {
+
 	type Op = A => A
+
+	// Initialization of the record with the current state and empyt list of ops
+
+	// FIXME: if we start with some initial first state, the log is empty, need to add "initial value op" or something
+//	private val log: Log[A] = new Log[A]()
 
 	def immutableState: A = value
 
 	// The -1 corresponds to the initial state where no operation is yet applied
-	def numOperations: Long = this.record.recordSize() - 1
+//	def numOperations: Long = this.record.recordSize() - 1
 
-	def getImmutableStates: List[A] =  this.record.getImmutableStates
+//	def getImmutableStates: List[A] =  this.record.getImmutableStates
 
-	def applyOp(operation: Op): Unit = {
+	def applyOp(operation: Op): AtomicObjectState[A] = {
 		// Operation must apply itself to the state
 		// but we want the state to take in the operations
 		// so that the framework can record the op
 		val result = operation.apply(this.value)
 
 		// Record the operation in the Log
-		this.record.updateRecord(result, operation)
-		this.value = result
+		val updatedLog = log.appended(LogRecord(value, operation, result))
+
+		return new AtomicObjectState[A](result, updatedLog)
+	}
+
+	override def equals(that: Any): Boolean = {
+		that match{
+			case that: AtomicObjectState[A] => this.immutableState == that.immutableState
+			case _ => false
+		}
+	}
+
+	override def toString: String = {
+		value.toString
+	}
+}
+
+object AtomicObjectState {
+	def initial[A](value: A): AtomicObjectState[A] = {
+		return new AtomicObjectState[A](value, Log.withInitialState(value))
+	}
+
+	def fromLog[A](log: Log[A]): AtomicObjectState[A] = {
+		return new AtomicObjectState[A](log.asList.last.stateResult, log)
 	}
 }

--- a/src/main/scala/rover/rdo/AtomicObjectState.scala
+++ b/src/main/scala/rover/rdo/AtomicObjectState.scala
@@ -4,20 +4,9 @@ import rover.rdo.client.{Log, LogRecord}
 
 // TODO: make ctor private
 class AtomicObjectState[A](private val value: A, private[rdo] val log: Log[A]) extends ObjectState {
-
 	type Op = A => A
 
-	// Initialization of the record with the current state and empyt list of ops
-
-	// FIXME: if we start with some initial first state, the log is empty, need to add "initial value op" or something
-//	private val log: Log[A] = new Log[A]()
-
 	def immutableState: A = value
-
-	// The -1 corresponds to the initial state where no operation is yet applied
-//	def numOperations: Long = this.record.recordSize() - 1
-
-//	def getImmutableStates: List[A] =  this.record.getImmutableStates
 
 	def applyOp(operation: Op): AtomicObjectState[A] = {
 		// Operation must apply itself to the state

--- a/src/main/scala/rover/rdo/AtomicObjectState.scala
+++ b/src/main/scala/rover/rdo/AtomicObjectState.scala
@@ -2,7 +2,7 @@ package rover.rdo
 
 class AtomicObjectState[A](private var value: A) extends ObjectState {
 	private var ops: List[Op] = List()
-	private var states: List[AtomicObjectState[A]] = List(new AtomicObjectState[A](value))
+	private var states: List[A] = List(value)
 
 	type Op = A => A
 
@@ -10,7 +10,7 @@ class AtomicObjectState[A](private var value: A) extends ObjectState {
 
 	def opsSize: Long = ops.length
 
-	def getStates: List[AtomicObjectState[A]] =  return states
+	def getStates: List[A] =  return states
 
 	def applyOp(operation: Op): Unit = {
 		// Operation must apply itself to the state
@@ -20,7 +20,7 @@ class AtomicObjectState[A](private var value: A) extends ObjectState {
 
 		// Record the operation in the "log" or "event stream" of operations
 		this.ops = this.ops :+ operation
-		this.states = this.states :+ new AtomicObjectState[A](result)
+		this.states = this.states :+ result
 
 		this.value = result
 	}

--- a/src/main/scala/rover/rdo/AtomicObjectState.scala
+++ b/src/main/scala/rover/rdo/AtomicObjectState.scala
@@ -3,14 +3,9 @@ package rover.rdo
 import rover.rdo.client.LogRecord
 
 class AtomicObjectState[A](private var value: A) extends ObjectState {
-//	private var ops: List[Op] = List()
-//	private var states: List[A] = List(value)
-
-	type Op = A => A
-
+	// Initialization of the record with the current state and empyt list of ops
 	private val record: LogRecord[A] = new LogRecord[A](List(value))
-
-
+	type Op = A => A
 
 	def immutableState: A = value
 
@@ -26,10 +21,7 @@ class AtomicObjectState[A](private var value: A) extends ObjectState {
 		val result = operation.apply(this.value)
 
 		// Record the operation in the Log
-		this.record.updateRecord(new AtomicObjectState[A](result), result, operation)
-//		this.ops = this.ops :+ operation
-//		this.states = this.states :+ result
-
+		this.record.updateRecord(result, operation)
 		this.value = result
 	}
 }

--- a/src/main/scala/rover/rdo/AtomicObjectState.scala
+++ b/src/main/scala/rover/rdo/AtomicObjectState.scala
@@ -2,10 +2,15 @@ package rover.rdo
 
 class AtomicObjectState[A](private var value: A) extends ObjectState {
 	private var ops: List[Op] = List()
+	private var states: List[AtomicObjectState[A]] = List(new AtomicObjectState[A](value))
 
 	type Op = A => A
 
 	def immutableState: A = value
+
+	def opsSize: Long = ops.length
+
+	def getStates: List[AtomicObjectState[A]] =  return states
 
 	def applyOp(operation: Op): Unit = {
 		// Operation must apply itself to the state
@@ -15,6 +20,7 @@ class AtomicObjectState[A](private var value: A) extends ObjectState {
 
 		// Record the operation in the "log" or "event stream" of operations
 		this.ops = this.ops :+ operation
+		this.states = this.states :+ new AtomicObjectState[A](result)
 
 		this.value = result
 	}

--- a/src/main/scala/rover/rdo/AtomicObjectState.scala
+++ b/src/main/scala/rover/rdo/AtomicObjectState.scala
@@ -1,22 +1,21 @@
 package rover.rdo
 
-abstract class AtomicObjectState[A <: AtomicObjectState[A]] extends ObjectState {
-	// binding this to a self-type A
-	this: A =>
-
+abstract class AtomicObjectState[A](private var value: A) extends ObjectState {
 	private var ops: List[Op] = List()
 
 	type Op = A => A
 
-	def applyOp(operation: Op): A = {
+	def immutableState: A = value
+
+	def applyOp(operation: Op): Unit = {
 		// Operation must apply itself to the state
 		// but we want the state to take in the operations
 		// so that the framework can record the op
-		val result = operation.apply(this)
+		val result = operation.apply(this.value)
 
 		// Record the operation in the "log" or "event stream" of operations
 		this.ops = this.ops :+ operation
 
-		return result
+		this.value = result
 	}
 }

--- a/src/main/scala/rover/rdo/AtomicObjectState.scala
+++ b/src/main/scala/rover/rdo/AtomicObjectState.scala
@@ -1,6 +1,6 @@
 package rover.rdo
 
-abstract class AtomicObjectState[A](private var value: A) extends ObjectState {
+class AtomicObjectState[A](private var value: A) extends ObjectState {
 	private var ops: List[Op] = List()
 
 	type Op = A => A

--- a/src/main/scala/rover/rdo/client/Log.scala
+++ b/src/main/scala/rover/rdo/client/Log.scala
@@ -1,7 +1,5 @@
 package rover.rdo.client
 
-import rover.rdo.AtomicObjectState
-
 /**
   * The class Log encapsulates the records from all the active RDOs. The Log
   * contains a map of [Long, LogRecord] key-value pairs.
@@ -16,7 +14,7 @@ class Log[A] {
   }
 
   def removeFromMap(key:Long): Unit ={
-    if (logMap contains(key)){
+    if (logMap contains key){
       this.logMap = this.logMap - key
     }
   }
@@ -25,50 +23,42 @@ class Log[A] {
 
 /**
   * This class encapsulates all the information stored to log regarding a single RDO
-  * The class's fields are a list of atomic states, a list of immutable states and a
+  * The class's fields are a list of immutable states and a
   * list of operations applied since the records instantiation.
   */
-class LogRecord[A] extends OperationType[A]{
-//  private var atomicStates: List[AtomicObjectState[A]] = List()
+class LogRecord[A]{
   private var immutableStates: List[A] = List()
   private var operations: List[Op] = List()
 
-//  type Op = A => A
+  type Op = A => A
 
   def this(immutableStates: List[A]) {
     this()
-//    this.atomicStates = atomicStates
     this.immutableStates = immutableStates
     this.operations = List()
   }
 
 
-  def recordSize() = this.immutableStates.length
+  def recordSize(): Int = this.immutableStates.length
 
   def getImmutableStates : List[A] = this.immutableStates
 
   // Since the lists are immutable, there is no append but rather a new object
-  def updateRecord(atomicState: AtomicObjectState[A], immutableState: A, operation: Op): Unit ={
-//    this.atomicStates = this.atomicStates :+ atomicState
+  def updateRecord(immutableState: A, operation: Op): Unit ={
     this.immutableStates = this.immutableStates :+ immutableState
     this.operations = this.operations :+ operation
   }
 
 
   /**
-    * This method empties the logRecord; at the flushing only the last atomic and immutable
+    * This method empties the logRecord; at the flushing only the last immutable
     * states of the RDO are kept, which are also the current ones. On the contrary, operations
     * are completely flushed.
     */
   //FIXME: there is server-client interaction here; conflict resolution protocol should be incorp
   def flushRecord(): Unit ={
-//    this.atomicStates = List[AtomicObjectState[A]](atomicStates.last)
     this.immutableStates = List[A](immutableStates.last)
     this.operations = List[Op]()
   }
 
-}
-
-trait OperationType[A]{
-  type Op = A => A
 }

--- a/src/main/scala/rover/rdo/client/Log.scala
+++ b/src/main/scala/rover/rdo/client/Log.scala
@@ -1,0 +1,74 @@
+package rover.rdo.client
+
+import rover.rdo.AtomicObjectState
+
+/**
+  * The class Log encapsulates the records from all the active RDOs. The Log
+  * contains a map of [Long, LogRecord] key-value pairs.
+  */
+//FIXME: Most probably should be moved to server side
+class Log[A] {
+
+  private var logMap: Map[Long, LogRecord[A]] = Map()
+
+  def addToMap(key: Long, value: LogRecord[A]): Unit ={
+    this.logMap = this.logMap + (key -> value)
+  }
+
+  def removeFromMap(key:Long): Unit ={
+    if (logMap contains(key)){
+      this.logMap = this.logMap - key
+    }
+  }
+
+}
+
+/**
+  * This class encapsulates all the information stored to log regarding a single RDO
+  * The class's fields are a list of atomic states, a list of immutable states and a
+  * list of operations applied since the records instantiation.
+  */
+class LogRecord[A] extends OperationType[A]{
+//  private var atomicStates: List[AtomicObjectState[A]] = List()
+  private var immutableStates: List[A] = List()
+  private var operations: List[Op] = List()
+
+//  type Op = A => A
+
+  def this(immutableStates: List[A]) {
+    this()
+//    this.atomicStates = atomicStates
+    this.immutableStates = immutableStates
+    this.operations = List()
+  }
+
+
+  def recordSize() = this.immutableStates.length
+
+  def getImmutableStates : List[A] = this.immutableStates
+
+  // Since the lists are immutable, there is no append but rather a new object
+  def updateRecord(atomicState: AtomicObjectState[A], immutableState: A, operation: Op): Unit ={
+//    this.atomicStates = this.atomicStates :+ atomicState
+    this.immutableStates = this.immutableStates :+ immutableState
+    this.operations = this.operations :+ operation
+  }
+
+
+  /**
+    * This method empties the logRecord; at the flushing only the last atomic and immutable
+    * states of the RDO are kept, which are also the current ones. On the contrary, operations
+    * are completely flushed.
+    */
+  //FIXME: there is server-client interaction here; conflict resolution protocol should be incorp
+  def flushRecord(): Unit ={
+//    this.atomicStates = List[AtomicObjectState[A]](atomicStates.last)
+    this.immutableStates = List[A](immutableStates.last)
+    this.operations = List[Op]()
+  }
+
+}
+
+trait OperationType[A]{
+  type Op = A => A
+}

--- a/src/main/scala/rover/rdo/client/RdObject.scala
+++ b/src/main/scala/rover/rdo/client/RdObject.scala
@@ -63,8 +63,10 @@ class CommonAncestor[A](private val one: RdObject[A], private val other: RdObjec
 	// determine it once and defer all RdObject methods to it
 	def commonAncestor: RdObject[A] = {
 		// determine here... & probably cache or is that not needed in scala? :S
-		// FIXME: proper determination (need to have whole range of intermediate
-		// versions available
+		// FIXME: currently we return just the atomic state..what about the outstanding operations?
+		// can there be a fork in the history of the provided RDOs?
+		// since client RDOs apply tentative updates there shouldn't be any, apart from the common ancestor
+		// FIXME: might need to keep track of history from the last stable point
 		for (i <- one.getValues.reverse) {
 			for (j <- other.getValues.reverse) {
 				if (currentVersion(new AtomicObjectState[A](i)) == currentVersion(new AtomicObjectState[A](j))) {

--- a/src/main/scala/rover/rdo/client/RdObject.scala
+++ b/src/main/scala/rover/rdo/client/RdObject.scala
@@ -5,41 +5,7 @@ import rover.rdo.AtomicObjectState
 //FIXME: use hashes instead of Longs/Strings?
 class RdObject[A](var state: AtomicObjectState[A]) {
 
-//	var state: AtomicObjectState[A] = null
-
-//	def this(state: AtomicObjectState[A]) = {
-//		this()
-//		this.state = state
-//	}
-
-	/**
-	  * The current version of the RDO instance, if current == stable
-	  * then the RDO does not contain any unsaved state changes
-	  * @return The current version of the RDO state
-	  */
-//	def currentVersion: Long = {
-//		return state.numOperations
-//	}
-
-	//FIXME: this is a crude method of ectractingthe version; we need a better method
-	//two states are equivalent here if merely the same amount of operations are performed
-//	def currentVersion(cstate: AtomicObjectState[A]): Long  = {
-//		return cstate.numOperations
-//	}
-
-	/**
-	  * The persisted (on master) version this RDO instance was based on
-	  * initially.
-	  * @return Version of persisted RDO state the instance has started with
-	  */
-//	def stableVersion: Long = {
-//		// TODO: determine from state
-//		null
-//	}
-
-
-//	def getImmutableStates: List[A] = state.getImmutableStates
-
+	// TODO: "is up to date" or "version" methods
 
 	protected final def modifyState(op: AtomicObjectState[A]#Op): Unit = {
 		state = state.applyOp(op)
@@ -68,12 +34,9 @@ class CommonAncestor[A](private val one: RdObject[A], private val other: RdObjec
 	def commonAncestor: RdObject[A] = {
 		// determine here... & probably cache or is that not needed in scala? :S
 		// FIXME: currently we return just the atomic state..what about the outstanding operations?
-		// can there be a fork in the history of the provided RDOs?
-		// since client RDOs apply tentative updates there shouldn't be any, apart from the common ancestor
-		// FIXME: might need to keep track of history from the last stable point
 		for (i <- one.state.log.asList.reverse) {
 			for (j <- other.state.log.asList.reverse) {
-//				if (currentVersion(new AtomicObjectState[A](i)) == currentVersion(new AtomicObjectState[A](j))) {
+
 				println()
 				println("I:" + i)
 				println("J:" + j)
@@ -87,41 +50,11 @@ class CommonAncestor[A](private val one: RdObject[A], private val other: RdObjec
 				}
 			}
 		}
-		throw new RuntimeException("HENK IS DEAD")
-//		return new RdObject[A]()
+		// FIXME: typed exception, better error logs
+		throw new RuntimeException("Failed to determine a common ancestor")
 	}
 
 	override def toString: String = {
 		commonAncestor.state.toString
 	}
-
-
-//	override def currentVersion: Long = {
-//		commonAncestor.currentVersion
-//	}
-//
-//	override def stableVersion: Long = {
-//		commonAncestor.stableVersion
-//	}
-//
-//	// FIXME: determine what to do with this, fix return value/type
-//    def hasDiverged: Long =  {
-//		// FIXME: non-logical result
-//	    if (this.currentVersion != other.currentVersion){
-//			commonAncestor.currentVersion
-//		}
-//		else{
-//			println("Non-divergent objects")
-//			this.currentVersion
-//		}
-//	}
-}
-
-class updateRDO(){
-	//TODO: apply tentative updates to RDO
-
-}
-
-class revertRDO(){
-	//TOD: also revert changes
 }

--- a/src/main/scala/rover/rdo/client/RdObject.scala
+++ b/src/main/scala/rover/rdo/client/RdObject.scala
@@ -18,13 +18,13 @@ class RdObject[A] () {
 	  * @return The current version of the RDO state
 	  */
 	def currentVersion: Long = {
-		return state.opsSize
+		return state.numOperations
 	}
 
 	//FIXME: this is a crude method of ectractingthe version; we need a better method
 	//two states are equivalent here if merely the same amount of operations are performed
 	def currentVersion(cstate: AtomicObjectState[A]): Long  = {
-		return cstate.opsSize
+		return cstate.numOperations
 	}
 
 	/**
@@ -38,7 +38,7 @@ class RdObject[A] () {
 //	}
 
 
-	def getValues: List[A] = state.getStates
+	def getImmutableStates: List[A] = state.getImmutableStates
 
 
 	protected final def modifyState(op: AtomicObjectState[A]#Op): Unit = {
@@ -67,8 +67,8 @@ class CommonAncestor[A](private val one: RdObject[A], private val other: RdObjec
 		// can there be a fork in the history of the provided RDOs?
 		// since client RDOs apply tentative updates there shouldn't be any, apart from the common ancestor
 		// FIXME: might need to keep track of history from the last stable point
-		for (i <- one.getValues.reverse) {
-			for (j <- other.getValues.reverse) {
+		for (i <- one.getImmutableStates.reverse) {
+			for (j <- other.getImmutableStates.reverse) {
 				if (currentVersion(new AtomicObjectState[A](i)) == currentVersion(new AtomicObjectState[A](j))) {
 					val ancestor = new RdObject[A](new AtomicObjectState[A](i))
 					return ancestor
@@ -79,7 +79,7 @@ class CommonAncestor[A](private val one: RdObject[A], private val other: RdObjec
 	}
 
 	override def toString: String = {
-		commonAncestor.getValues.toString()
+		commonAncestor.getImmutableStates.toString()
 	}
 
 

--- a/src/main/scala/rover/rdo/client/RdObject.scala
+++ b/src/main/scala/rover/rdo/client/RdObject.scala
@@ -31,13 +31,13 @@ class RdObject[A] () {
 	  * initially.
 	  * @return Version of persisted RDO state the instance has started with
 	  */
-	def stableVersion: Long = {
-		// TODO: determine from state
-		null
-	}
+//	def stableVersion: Long = {
+//		// TODO: determine from state
+//		null
+//	}
 
 
-	def getStates: List[AtomicObjectState[A]] = state.getStates
+	def getValues: List[A] = state.getStates
 
 
 	protected final def modifyState(op: AtomicObjectState[A]#Op): Unit = {
@@ -64,11 +64,11 @@ class CommonAncestor[A](private val one: RdObject[A], private val other: RdObjec
 		// determine here... & probably cache or is that not needed in scala? :S
 		// FIXME: proper determination (need to have whole range of intermediate
 		// versions available
-		for (i <- one.getStates) {
-			for (j <- other.getStates) {
+		for (i <- one.getValues) {
+			for (j <- other.getValues) {
 
-				if (currentVersion(i) == currentVersion(j)) {
-					val ancestor = new RdObject[A](new AtomicObjectState[A](i.immutableState))
+				if (currentVersion(new AtomicObjectState[A](i)) == currentVersion(new AtomicObjectState[A](j))) {
+					val ancestor = new RdObject[A](new AtomicObjectState[A](i))
 					return ancestor
 				}
 			}

--- a/src/main/scala/rover/rdo/client/RdObject.scala
+++ b/src/main/scala/rover/rdo/client/RdObject.scala
@@ -11,17 +11,18 @@ class RdObject[A] () {
 		this()
 		this.state = state
 	}
+
 	/**
 	  * The current version of the RDO instance, if current == stable
 	  * then the RDO does not contain any unsaved state changes
 	  * @return The current version of the RDO state
 	  */
 	def currentVersion: Long = {
-		// FIXME: crude way of defining an RDO's version
-		// Fancier methods could also be used as hashes/crypto
 		return state.opsSize
 	}
 
+	//FIXME: this is a crude method of ectractingthe version; we need a better method
+	//two states are equivalent here if merely the same amount of operations are performed
 	def currentVersion(cstate: AtomicObjectState[A]): Long  = {
 		return cstate.opsSize
 	}
@@ -60,13 +61,12 @@ class RdObject[A] () {
 class CommonAncestor[A](private val one: RdObject[A], private val other: RdObject[A]) extends RdObject[A] {
 
 	// determine it once and defer all RdObject methods to it
-	private def commonAncestor: RdObject[A] = {
+	def commonAncestor: RdObject[A] = {
 		// determine here... & probably cache or is that not needed in scala? :S
 		// FIXME: proper determination (need to have whole range of intermediate
 		// versions available
-		for (i <- one.getValues) {
-			for (j <- other.getValues) {
-
+		for (i <- one.getValues.reverse) {
+			for (j <- other.getValues.reverse) {
 				if (currentVersion(new AtomicObjectState[A](i)) == currentVersion(new AtomicObjectState[A](j))) {
 					val ancestor = new RdObject[A](new AtomicObjectState[A](i))
 					return ancestor
@@ -74,6 +74,10 @@ class CommonAncestor[A](private val one: RdObject[A], private val other: RdObjec
 			}
 		}
 		return new RdObject[A]()
+	}
+
+	override def toString: String = {
+		commonAncestor.getValues.toString()
 	}
 
 

--- a/src/main/scala/rover/rdo/client/RdObject.scala
+++ b/src/main/scala/rover/rdo/client/RdObject.scala
@@ -1,21 +1,31 @@
 package rover.rdo.client
 
-//FIXME: use hashes instead of Longs/Strings
-trait RdObject {
+import rover.rdo.AtomicObjectState
+
+//FIXME: use hashes instead of Longs/Strings?
+abstract class RdObject[A] (private var state: AtomicObjectState[A]) {
 
 	/**
 	  * The current version of the RDO instance, if current == stable
 	  * then the RDO does not contain any unsaved state changes
 	  * @return The current version of the RDO state
 	  */
-	def currentVersion: Long
+	def currentVersion: Long // TODO: determine from state
 
 	/**
 	  * The persisted (on master) version this RDO instance was based on
 	  * initially.
 	  * @return Version of persisted RDO state the instance has started with
 	  */
-	def stableVersion: Long
+	def stableVersion: Long // TODO: determine from state
+
+	protected final def modifyState(op: AtomicObjectState[A]#Op): Unit = {
+		state.applyOp(op)
+	}
+
+	protected final def immutableState: A = {
+		return state.immutableState
+	}
 }
 
 /**
@@ -26,36 +36,36 @@ trait RdObject {
   * @param one Some RDO
   * @param other Some other RDO
   */
-class CommonAncestor[RDO <: RdObject](private val one: RDO, private val other: RDO) extends RdObject {
-
-	// determine it once and defer all RdObject methods to it
-	private val commonAncestor: RDO = {
-		// determine here... & probably cache or is that not needed in scala? :S
-		// FIXME: proper determination (need to have whole range of intermediate
-		// versions available
-		one
-	}
-
-	override def currentVersion: Long = {
-		commonAncestor.currentVersion
-	}
-
-	override def stableVersion: Long = {
-		commonAncestor.stableVersion
-	}
-
-	// FIXME: determine what to do with this, fix return value/type
-    def hasDiverged: Long =  {
-		// FIXME: non-logical result
-	    if (this.currentVersion != other.currentVersion){
-			commonAncestor.currentVersion
-		}
-		else{
-			println("Non-divergent objects")
-			this.currentVersion
-		}
-	}
-}
+//class CommonAncestor[RDO <: RdObject](private val one: RDO, private val other: RDO) extends RdObject {
+//
+//	// determine it once and defer all RdObject methods to it
+//	private val commonAncestor: RDO = {
+//		// determine here... & probably cache or is that not needed in scala? :S
+//		// FIXME: proper determination (need to have whole range of intermediate
+//		// versions available
+//		one
+//	}
+//
+//	override def currentVersion: Long = {
+//		commonAncestor.currentVersion
+//	}
+//
+//	override def stableVersion: Long = {
+//		commonAncestor.stableVersion
+//	}
+//
+//	// FIXME: determine what to do with this, fix return value/type
+//    def hasDiverged: Long =  {
+//		// FIXME: non-logical result
+//	    if (this.currentVersion != other.currentVersion){
+//			commonAncestor.currentVersion
+//		}
+//		else{
+//			println("Non-divergent objects")
+//			this.currentVersion
+//		}
+//	}
+//}
 
 class updateRDO(){
 	//TODO: apply tentative updates to RDO

--- a/src/main/scala/votingapp/Poll.scala
+++ b/src/main/scala/votingapp/Poll.scala
@@ -22,29 +22,36 @@ class PollResult(private  val votes: Votes) {
 
 case class PollChoice(choice: String)
 
-class Votes(val asMap: Map[PollChoice, Int]) extends AtomicObjectState[Votes] {
+class Votes(val map: Map[PollChoice, Int]) extends AtomicObjectState[Map[PollChoice, Int]](map) {
 	/**
 	  * Adds the given poll choice to the votes cast. Also: immutable object pattern.
 	  * @param vote The vote-choice to cast
 	  * @return New state with the vote added
 	  */
-	def add(vote: PollChoice): Votes = {
-		return applyOp(new CastVoteOp(vote))
+	def add(vote: PollChoice): Unit = {
+		applyOp(state => {
+			if (state contains vote) {
+				state updated (vote, state(vote) + 1)
+			}
+			else {
+				state updated (vote, 1)
+			}
+		})
 	}
 
 	def majorityChoice: PollChoice = {
 		// FIXME: ties, idea: return a "poll-result" not the choice
-		val winner = this.asMap.maxBy(_._2)._1
+		val winner = this.immutableState.maxBy(_._2)._1
 		return winner
 	}
 
 	override def toString: String = {
-		asMap.toString
+		immutableState.toString
 	}
 }
 
 object Votes {
-	def apply(choices: List[PollChoice]) : Votes = {
+	def apply(choices: List[PollChoice]): Votes= {
 		// TODO: maybe remove, not needed anymore... we accept any choice? Or enforce only valid choices
 		return new Votes(choices.map(choice => (choice,0)).toMap)
 	}
@@ -55,16 +62,16 @@ object Votes {
 }
 
 // app code
-class CastVoteOp(private val vote: PollChoice) extends Votes#Op {
-	final override def apply(state: Votes): Votes = {
-		if (state.asMap contains vote) {
-			Votes(state.asMap updated (vote, state.asMap(vote) + 1))
-		}
-		else {
-			Votes(state.asMap updated (vote, 1))
-		}
-	}
-}
+//class CastVoteOp(private val vote: PollChoice) extends Votes#Op {
+//	final override def apply(state: Votes): Votes = {
+//		if (state.asMap contains vote) {
+//			Votes(state.asMap updated (vote, state.asMap(vote) + 1))
+//		}
+//		else {
+//			Votes(state.asMap updated (vote, 1))
+//		}
+//	}
+//}
 
 object henk {
 	def main(args: Array[String]): Unit = {

--- a/src/main/scala/votingapp/Poll.scala
+++ b/src/main/scala/votingapp/Poll.scala
@@ -16,8 +16,8 @@ class Poll(val question: String, val choices: List[PollChoice]) extends RdObject
 
 	override def toString: String = immutableState.toString
 
-	override def currentVersion: Long = 0
-	override def stableVersion: Long = 0
+//	override def currentVersion: Long = 0
+//	override def stableVersion: Long = 0
 }
 
 class PollResult(private  val votes: Votes) {

--- a/src/main/scala/votingapp/Poll.scala
+++ b/src/main/scala/votingapp/Poll.scala
@@ -3,7 +3,7 @@ package votingapp
 import rover.rdo.AtomicObjectState
 import rover.rdo.client.RdObject
 
-class Poll(val question: String, val choices: List[PollChoice]) extends RdObject(new AtomicObjectState(Votes(choices))) {
+class Poll(val question: String, val choices: List[PollChoice]) extends RdObject[Votes](new AtomicObjectState[Votes](Votes(choices))) {
 
 	def cast(vote: PollChoice): Unit = {
 		modifyState(votes => votes.add(vote))
@@ -28,7 +28,7 @@ class PollResult(private  val votes: Votes) {
 
 case class PollChoice(choice: String)
 
-class Votes(val map: Map[PollChoice, Int]){
+class Votes(val map: Map[PollChoice, Int]) {
 	/**
 	  * Adds the given poll choice to the votes cast. Also: immutable object pattern.
 	  * @param vote The vote-choice to cast
@@ -70,6 +70,8 @@ object henk {
 		poll.cast(PollChoice("No"))
 		println(poll)
 		println(poll.result.winner)
+		println("Immutable state:" + poll.toString)
+
 
 	}
 }

--- a/src/main/scala/votingapp/Poll.scala
+++ b/src/main/scala/votingapp/Poll.scala
@@ -6,7 +6,7 @@ class Poll(val question: String, val choices: List[PollChoice]) {
 	var votes: Votes = Votes(choices)
 
 	def cast(vote: PollChoice): Unit = {
-		println(s"Casting vote: $vote")
+		votes.add(vote)
 	}
 
 	def result: PollResult = {
@@ -29,13 +29,9 @@ class Votes(val map: Map[PollChoice, Int]) extends AtomicObjectState[Map[PollCho
 	  * @return New state with the vote added
 	  */
 	def add(vote: PollChoice): Unit = {
+		println(s"Casting vote: $vote")
 		applyOp(state => {
-			if (state contains vote) {
-				state updated (vote, state(vote) + 1)
-			}
-			else {
-				state updated (vote, 1)
-			}
+			state updated (vote, state(vote) + 1)
 		})
 	}
 
@@ -53,11 +49,11 @@ class Votes(val map: Map[PollChoice, Int]) extends AtomicObjectState[Map[PollCho
 object Votes {
 	def apply(choices: List[PollChoice]): Votes= {
 		// TODO: maybe remove, not needed anymore... we accept any choice? Or enforce only valid choices
-		return new Votes(choices.map(choice => (choice,0)).toMap)
+		return new Votes(choices.map(choice => (choice,0)).toMap.withDefaultValue(0))
 	}
 
 	def apply(votes: Map[PollChoice, Int]): Votes = {
-		return new Votes(votes)
+		return new Votes(votes.withDefaultValue(0))
 	}
 }
 
@@ -79,6 +75,7 @@ object henk {
 		println(poll.votes)
 
 		poll.cast(PollChoice("Yes"))
+		poll.cast(PollChoice("No"))
 		poll.cast(PollChoice("No"))
 		println(poll.votes)
 		println(poll.result.winner)

--- a/src/main/scala/votingapp/Poll.scala
+++ b/src/main/scala/votingapp/Poll.scala
@@ -1,9 +1,9 @@
 package votingapp
 
 import rover.rdo.AtomicObjectState
-import rover.rdo.client.RdObject
+import rover.rdo.client.{CommonAncestor, RdObject}
 
-class Poll(val question: String, val choices: List[PollChoice]) extends RdObject[Votes](new AtomicObjectState[Votes](Votes(choices))) {
+case class Poll(val question: String, val choices: List[PollChoice]) extends RdObject[Votes](new AtomicObjectState[Votes](Votes(choices))) {
 
 	def cast(vote: PollChoice): Unit = {
 		modifyState(votes => votes.add(vote))
@@ -62,13 +62,18 @@ object Votes {
 
 object henk {
 	def main(args: Array[String]): Unit = {
-		var poll = new Poll("Does this work", List(PollChoice("Yes"), PollChoice("No"), PollChoice("I hope so"), PollChoice("Yes")))
+		val poll = new Poll("Does this work", List(PollChoice("Yes"), PollChoice("No"), PollChoice("I hope so"), PollChoice("Yes")))
+		val poll2 = poll.copy()
 		println(poll)
 
 		poll.cast(PollChoice("Yes"))
 		poll.cast(PollChoice("No"))
-		poll.cast(PollChoice("No"))
-		println(poll)
+		poll2.cast(PollChoice("No"))
+		poll2.cast(PollChoice("No"))
+		println("Poll:" + poll)
+		println("Poll2:" + poll2)
+		val parent = new CommonAncestor[Votes](poll, poll2)
+		println("Parent:" + parent.toString)
 		println(poll.result.winner)
 		println("Immutable state:" + poll.toString)
 


### PR DESCRIPTION
Worked on this with Philipe, not everything is 100% when it comes to the two "apps" but the framework is.

Extracted all AtomicObjectState state management to the Log. Due to scala constructor bull*, had to work around some things with companion objects, not completely satisfied in all cases but it suffices for now