### PR TITLE
Refactor object

### DIFF
--- a/src/main/scala/chatapp/ChatConflictResolutionMechanism.scala
+++ b/src/main/scala/chatapp/ChatConflictResolutionMechanism.scala
@@ -1,6 +1,7 @@
 package chatapp
 
-import rover.rdo.conflict.provided.AppendIncomingChangesMergeResolve
+import chatapp.model.ChatMessage
+import rover.rdo.conflict.resolve.AppendIncomingChangesMergeResolve
 
 class ChatConflictResolutionMechanism extends AppendIncomingChangesMergeResolve[List[ChatMessage]] {
 }

--- a/src/main/scala/chatapp/Client.scala
+++ b/src/main/scala/chatapp/Client.scala
@@ -48,7 +48,7 @@ class ChatClient(serverAddress: String) extends
 //		println(s"Sending message with intial state: ${chat.state}")
 		async {
 			await(chat.send(new ChatMessage(message, user)))
-			exportRDO(chat.state)
+			exportRDO(ObjectId.generateFromString("chat"))
 			//			await(session.exportRDO("chat", chat))
 //			updater(chat.state)
 		}

--- a/src/main/scala/chatapp/Client.scala
+++ b/src/main/scala/chatapp/Client.scala
@@ -48,7 +48,7 @@ class ChatClient(serverAddress: String) extends
 //		println(s"Sending message with intial state: ${chat.state}")
 		async {
 			await(chat.send(new ChatMessage(message, user)))
-			exportRDO("chat", chat.state)
+			exportRDO(chat.state)
 			//			await(session.exportRDO("chat", chat))
 //			updater(chat.state)
 		}

--- a/src/main/scala/chatapp/Client.scala
+++ b/src/main/scala/chatapp/Client.scala
@@ -3,7 +3,7 @@ package chatapp
 import chatapp.model.{Chat, ChatMessage}
 import chatapp.ui.REPL
 import rover.Client.OAuth2Credentials
-import rover.rdo.RdObject
+import rover.rdo.{ObjectId, RdObject}
 import rover.{HTTPClient, Session}
 
 import scala.async.Async.{async, await}
@@ -37,7 +37,7 @@ class ChatClient(serverAddress: String) extends
 			val credentials = new OAuth2Credentials("fake credentials",  "fake credentials")
 			this.user = user
 			session = createSession(credentials)
-			val state = importRDO("chat")
+			val state = importRDO(ObjectId.generateFromString("chat"))
 			val rdo = new RdObject[List[ChatMessage]](state)
 			chat = Chat.fromRDO(rdo)
 //			println(s"Initial state: ${chat.state}")
@@ -60,11 +60,12 @@ class ChatClient(serverAddress: String) extends
 //				val serverState = await(importRDO("chat")).asInstanceOf[RdObject[List[ChatMessage]]]
 //				chat = Chat.fromRDO(serverState, updater)
 //				println(s"Updating state from update loop...")
-				val state = importRDO("chat")
+				val stateId = ObjectId.generateFromString("chat")
+				val state = importRDO(stateId)
 //				println(s"Got updated state: $state")
 				//				chat = Chat.fromRDO(rdo, updater)
 
-				appendedState("chat", state)
+				appendedState(stateId, state)
 				chat.state = state
 
 //				println(s"Rendering chat state: ${chat.state}")

--- a/src/main/scala/chatapp/Client.scala
+++ b/src/main/scala/chatapp/Client.scala
@@ -1,7 +1,9 @@
 package chatapp
 
+import chatapp.model.{Chat, ChatMessage}
+import chatapp.ui.REPL
 import rover.Client.OAuth2Credentials
-import rover.rdo.client.RdObject
+import rover.rdo.RdObject
 import rover.{HTTPClient, Session}
 
 import scala.async.Async.{async, await}

--- a/src/main/scala/chatapp/Server.scala
+++ b/src/main/scala/chatapp/Server.scala
@@ -2,10 +2,11 @@ package chatapp
 
 import chatapp.model.ChatMessage
 import rover.HTTPServer
+import rover.rdo.ObjectId
 import rover.rdo.state.AtomicObjectState
 
 
-class ChatServer extends HTTPServer[List[ChatMessage]](_mapToStates = Map("chat" -> ChatServer.CHAT_STATE)) {
+class ChatServer extends HTTPServer[List[ChatMessage]](_mapToStates = Map(ObjectId.generateFromString("chat") -> ChatServer.CHAT_STATE)) {
 
 }
 

--- a/src/main/scala/chatapp/Server.scala
+++ b/src/main/scala/chatapp/Server.scala
@@ -1,8 +1,7 @@
 package chatapp
 
-import rover.Client.OAuth2Credentials
+import rover.HTTPServer
 import rover.rdo.state.AtomicObjectState
-import rover.{Client, Server, Session, HTTPServer}
 
 
 class ChatServer extends HTTPServer[List[ChatMessage]](_mapToStates = Map("chat" -> ChatServer.CHAT_STATE)) {

--- a/src/main/scala/chatapp/Server.scala
+++ b/src/main/scala/chatapp/Server.scala
@@ -1,5 +1,6 @@
 package chatapp
 
+import chatapp.model.ChatMessage
 import rover.HTTPServer
 import rover.rdo.state.AtomicObjectState
 

--- a/src/main/scala/chatapp/model/Chat.scala
+++ b/src/main/scala/chatapp/model/Chat.scala
@@ -2,7 +2,7 @@ package chatapp.model
 
 import chatapp.{ChatConflictResolutionMechanism, ChatUser}
 import rover.rdo.RdObject
-import rover.rdo.conflict.ConflictedState
+import rover.rdo.conflict.{CommonAncestor, ConflictedState}
 import rover.rdo.state.{AtomicObjectState, InitialAtomicObjectState}
 
 import scala.async.Async.async
@@ -49,7 +49,7 @@ object Chat {
 
 object test {
 	def main(args: Array[String]): Unit ={
-		val initialState = new InitialAtomicObjectState[List[ChatMessage]](List(new ChatMessage("initiating", new ChatUser("system"))))
+		val initialState = new InitialAtomicObjectState[List[ChatMessage]](List(new ChatMessage("Welcome", new ChatUser("system"))))
 		val chat = new Chat(initialState)
 		val THREAD_SLEEP = 1000
 

--- a/src/main/scala/chatapp/model/Chat.scala
+++ b/src/main/scala/chatapp/model/Chat.scala
@@ -1,14 +1,13 @@
-package chatapp
+package chatapp.model
 
-import rover.rdo.CommonAncestor
-import rover.rdo.client.RdObject
+import chatapp.{ChatConflictResolutionMechanism, ChatUser}
+import rover.rdo.RdObject
 import rover.rdo.conflict.ConflictedState
 import rover.rdo.state.{AtomicObjectState, InitialAtomicObjectState}
 
+import scala.async.Async.async
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.async.Async.{async, await}
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
+import scala.concurrent.Future
 
 
 // FIXME: ensure messages can be read, but not modified or reassigned...

--- a/src/main/scala/chatapp/model/Message.scala
+++ b/src/main/scala/chatapp/model/Message.scala
@@ -1,6 +1,8 @@
-package chatapp
-import io.circe._, io.circe.syntax._
-import io.circe.{Encoder, Json}
+package chatapp.model
+
+import chatapp.ChatUser
+import io.circe.syntax._
+import io.circe.{Encoder, Json, _}
 
 
 class ChatMessage(val body: String,

--- a/src/main/scala/chatapp/ui/CLI.scala
+++ b/src/main/scala/chatapp/ui/CLI.scala
@@ -1,4 +1,4 @@
-package chatapp
+package chatapp.ui
 
 import cats.implicits._
 import com.monovore.decline._

--- a/src/main/scala/chatapp/ui/REPL.scala
+++ b/src/main/scala/chatapp/ui/REPL.scala
@@ -1,8 +1,8 @@
-package chatapp
+package chatapp.ui
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Await, Future, Promise}
 import scala.async.Async.{async, await}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 
 class REPL[A](reader: REPL[A]#Reader, executor: REPL[A]#Executor, printer: REPL[A]#Printer) {

--- a/src/main/scala/rover/Client.scala
+++ b/src/main/scala/rover/Client.scala
@@ -11,6 +11,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.async.Async.{async, await}
 import io.circe._
+import rover.rdo.ObjectId
 import rover.rdo.state.AtomicObjectState
 
 /**
@@ -21,8 +22,9 @@ import rover.rdo.state.AtomicObjectState
   * @param mapToStates, map to up-to-date version of local RDOs
   */
 //FIXME: create a unique, static id for each RDO upon its creation
-class Client[C, A](protected val serverAddress: String, protected val identifier: Session[C, A]#Identifier,
-                   protected var mapToStates: Map[String, AtomicObjectState[A]] = Map[String, AtomicObjectState[A]]()){
+class Client[C, A](protected val serverAddress: String,
+                   protected val identifier: Session[C, A]#Identifier,
+                   protected var mapToStates: Map[ObjectId, AtomicObjectState[A]] = Map[ObjectId, AtomicObjectState[A]]()) {
 
 
   val server = Server.fromAddress[C,A](serverAddress)
@@ -30,11 +32,11 @@ class Client[C, A](protected val serverAddress: String, protected val identifier
     server.createSession(credentials, this.identifier)
   }
 
-  def appendedState(stateId: String, atomicState: AtomicObjectState[A]): Unit ={
+  def appendedState(stateId: ObjectId, atomicState: AtomicObjectState[A]): Unit ={
     this.mapToStates = this.mapToStates + (stateId -> atomicState)
   }
 
-  def getAtomicStateWithId(stateId: String): AtomicObjectState[A] ={
+  def getAtomicStateWithId(stateId: ObjectId): AtomicObjectState[A] ={
     return mapToStates(stateId)
   }
 }
@@ -49,7 +51,8 @@ object Client {
   }
 }
 
-class HTTPClient[A](_serverAddress: String, _identifier: Session[OAuth2Credentials, A]#Identifier)(implicit val encodeA: Encoder[A], implicit val decodeA: Decoder[A]) extends Client[OAuth2Credentials, A](_serverAddress, _identifier) {
+class HTTPClient[A](_serverAddress: String, _identifier: Session[OAuth2Credentials, A]#Identifier)
+                   (implicit val encodeA: Encoder[A], implicit val decodeA: Decoder[A]) extends Client[OAuth2Credentials, A](_serverAddress, _identifier) {
 
     implicit val stateEncoder: Encoder[AtomicObjectState[A]] = Encoder.forProduct1("immutableState")(rdo => (rdo.immutableState))
   //	implicit val stateDecoder: Decoder[AtomicObjectState[List[ChatMessage]]] = deriveDecoder[AtomicObjectState[List[ChatMessage]]]
@@ -64,12 +67,12 @@ class HTTPClient[A](_serverAddress: String, _identifier: Session[OAuth2Credentia
 			}
 	}
 
-  def importRDO(objectId: String): AtomicObjectState[A] = {
+  def importRDO(objectId: ObjectId): AtomicObjectState[A] = {
     val roverClient = lol.http.Client(serverAddress, 8888, "http")
     val userAgent = h"User-Agent" -> h"lolhttp"
 
     val getState = (for {
-      result <- roverClient.run(Get(s"/api/rdo/$objectId").addHeaders(userAgent)) {
+      result <- roverClient.run(Get(s"/api/rdo/${objectId.asString}").addHeaders(userAgent)) {
         _.readSuccessAs[Json].map(json => {
           json.as[AtomicObjectState[A]]
         })
@@ -93,7 +96,7 @@ class HTTPClient[A](_serverAddress: String, _identifier: Session[OAuth2Credentia
 
 //    println(s"Exporting RDO $objectId as $state")
     val setState = (for {
-      result <- roverClient.run(Post(s"/api/rdo/${state.objectId}", stateEncoder.apply(state).toString).addHeaders(userAgent)) {
+      result <- roverClient.run(Post(s"/api/rdo/${state.objectId.asString}", stateEncoder.apply(state).toString).addHeaders(userAgent)) {
         _.readSuccessAs[Json].map(json => {
 //          println(s"Received JSON response: $json")
 //          json.as[AtomicObjectState[A]]

--- a/src/main/scala/rover/Client.scala
+++ b/src/main/scala/rover/Client.scala
@@ -87,13 +87,13 @@ class HTTPClient[A](_serverAddress: String, _identifier: Session[OAuth2Credentia
 
   }
 
-  def exportRDO(objectId: String, state: AtomicObjectState[A]): Unit = {
+  def exportRDO(state: AtomicObjectState[A]): Unit = {
     val roverClient = lol.http.Client(serverAddress, 8888, "http")
     val userAgent = h"User-Agent" -> h"lolhttp"
 
 //    println(s"Exporting RDO $objectId as $state")
     val setState = (for {
-      result <- roverClient.run(Post(s"/api/rdo/$objectId", stateEncoder.apply(state).toString).addHeaders(userAgent)) {
+      result <- roverClient.run(Post(s"/api/rdo/${state.objectId}", stateEncoder.apply(state).toString).addHeaders(userAgent)) {
         _.readSuccessAs[Json].map(json => {
 //          println(s"Received JSON response: $json")
 //          json.as[AtomicObjectState[A]]

--- a/src/main/scala/rover/Client.scala
+++ b/src/main/scala/rover/Client.scala
@@ -90,13 +90,14 @@ class HTTPClient[A](_serverAddress: String, _identifier: Session[OAuth2Credentia
 
   }
 
-  def exportRDO(state: AtomicObjectState[A]): Unit = {
+  def exportRDO(objectId: ObjectId): Unit = {
     val roverClient = lol.http.Client(serverAddress, 8888, "http")
     val userAgent = h"User-Agent" -> h"lolhttp"
+    val state = this.getAtomicStateWithId(objectId)
 
 //    println(s"Exporting RDO $objectId as $state")
     val setState = (for {
-      result <- roverClient.run(Post(s"/api/rdo/${state.objectId.asString}", stateEncoder.apply(state).toString).addHeaders(userAgent)) {
+      result <- roverClient.run(Post(s"/api/rdo/${objectId.asString}", stateEncoder.apply(state).toString).addHeaders(userAgent)) {
         _.readSuccessAs[Json].map(json => {
 //          println(s"Received JSON response: $json")
 //          json.as[AtomicObjectState[A]]

--- a/src/main/scala/rover/RoverApplication.scala
+++ b/src/main/scala/rover/RoverApplication.scala
@@ -1,0 +1,6 @@
+package rover
+
+import rover.rdo.client.RdObject
+
+abstract class RoverApplication[A, C, RDO <: RdObject[A]](server: Server[A,C]) {
+}

--- a/src/main/scala/rover/RoverApplication.scala
+++ b/src/main/scala/rover/RoverApplication.scala
@@ -1,6 +1,16 @@
 package rover
 
-import rover.rdo.client.RdObject
+import rover.rdo.RdObject
 
+/**
+  * This is a sort of combined repository & factory for RdObjects
+  * Currently every RdObject is implemented with AtomicStateObjects
+  *
+  * @param server
+  * @tparam A
+  * @tparam C
+  * @tparam RDO
+  */
 abstract class RoverApplication[A, C, RDO <: RdObject[A]](server: Server[A,C]) {
+	def checkoutObject(id: String)
 }

--- a/src/main/scala/rover/Server.scala
+++ b/src/main/scala/rover/Server.scala
@@ -1,12 +1,16 @@
 package rover
 
+import java.lang
+import java.lang.System
+
 import cats.effect.IO
 import io.circe._
 import io.circe.syntax._
+import lol.http
 import lol.http._
 import lol.json._
 import rover.Client.OAuth2Credentials
-import rover.rdo.RdObject
+import rover.rdo.{ObjectId, RdObject}
 import rover.rdo.conflict.ConflictedState
 import rover.rdo.conflict.resolve.AppendIncomingChangesMergeResolve
 import rover.rdo.state.AtomicObjectState
@@ -22,31 +26,42 @@ import scala.util.Try
   * @tparam C type of credentials used for sessions (e.g. OAuth2Credentials for OAuth type of auth)
   * @tparam A type of state of the application (e.g. "Votes" in a poll app, List[Messages] in a chatapp)
 */
-class Server[C, A]( protected val address: String,
-                    protected val mapToClients: Map[Session[C, A]#Identifier, Client[C, A]],
-                    protected var mapToStates: Map[String, AtomicObjectState[A]]) {
+class Server[C, A](protected val address: String,
+                   protected val mapToClients: Map[Session[C, A]#Identifier,
+                     Client[C, A]], protected var mapToStates: Map[ObjectId, AtomicObjectState[A]]) {
 
   //FIXME: Does the server has its own creds? It merely keeps track of clients' creds
 //  val credentials = null
 
   // TODO: Determine what to do with this
   def clientFromCredentials(credentials: Session[C,A]#Identifier): Client[C, A] = {
-    new Client[C, A](this.address, credentials, Map[String, AtomicObjectState[A]]())
+    new Client[C, A](this.address, credentials, Map[ObjectId, AtomicObjectState[A]]())
   }
 
   def createSession(credentials: C, identifier: Session[C,A]#Identifier): Session[C, A] = {
     new Session[C, A](credentials, this, clientFromCredentials(identifier))
   }
 
-  def getAtomicStateWithId(stateId: String): AtomicObjectState[A] = {
+  def containsStateId(stateId: ObjectId): Boolean = {
+    return this.mapToStates.contains(stateId)
+  }
+
+  def mapAtomicState(state: AtomicObjectState[A]) = {
+    if (!mapToStates.values.exists(_ == state)){
+      val objectId = ObjectId.generateNew()
+      this.mapToStates = this.mapToStates + (objectId -> state)
+    } else lang.System.err.println("Input state already exists")
+  }
+
+  def getAtomicStateWithId(stateId: ObjectId): AtomicObjectState[A] = {
         return mapToStates(stateId)
   }
 
-  def deliveredState(stateId: String, incomingState: AtomicObjectState[A]): Unit ={
+  def deliveredState(stateId: ObjectId, incomingState: AtomicObjectState[A]): Unit ={
     this.mapToStates = this.mapToStates + (stateId -> incomingState)
   }
 
-  def receivedState(stateId: String, incomingState: AtomicObjectState[A]): Unit ={
+  def receivedState(stateId: ObjectId, incomingState: AtomicObjectState[A]): Unit ={
     val serverState = mapToStates(stateId)
     if (serverState != incomingState){
       val conflictedState = ConflictedState.from(serverState, incomingState)
@@ -62,7 +77,7 @@ class Server[C, A]( protected val address: String,
 class HTTPServer[A](
   val port: Int = 8888,
   _mapToClients: Map[Session[OAuth2Credentials, A]#Identifier, Client[OAuth2Credentials, A]] = Map[Session[OAuth2Credentials, A]#Identifier, Client[OAuth2Credentials, A]](),
-  _mapToStates: Map[String, AtomicObjectState[A]] = Map[String, AtomicObjectState[A]]()
+  _mapToStates: Map[ObjectId, AtomicObjectState[A]] = Map[ObjectId, AtomicObjectState[A]]()
 )(implicit val encodeA: Encoder[A], implicit val decodeA: Decoder[A]) extends Server[OAuth2Credentials, A]("bla", _mapToClients, _mapToStates) {
   def Error(msg: String): Json = Json.obj("error" -> Json.fromString(msg))
 
@@ -92,9 +107,9 @@ class HTTPServer[A](
 		// Nothing special here, but look how we handle the 404 case.
 		case GET at url"/api/rdo/$id" =>
       println(mapToStates)
-      println(s"Getting $id from $mapToStates")
+      println(s"Getting $id from ${_mapToStates}")
 			IO {
-				Try(id).toOption.flatMap(mapToStates.get).map { state =>
+				Try(ObjectId.generateFromString(id)).toOption.flatMap(_mapToStates.get).map { state =>
 					Ok(state.asJson)
 				}.getOrElse {
 					NotFound(Error(s"No rdo found for id: `$id'"))
@@ -103,7 +118,7 @@ class HTTPServer[A](
 
     case request @ POST at url"/api/rdo/$id" =>
       println(s"Handling POST request for $id")
-      Try(id).toOption.flatMap(mapToStates.get).map { state =>
+      Try(ObjectId.generateFromString(id)).toOption.flatMap(_mapToStates.get).map { state =>
         // TODO: Decide what to return here
 //        val existing: RdObject[A] = new RdObject[A](state)
         request.readAs[Json].map { jsonBody =>
@@ -114,7 +129,7 @@ class HTTPServer[A](
             InternalServerError(Error(s"${failure.message}: \n${failure.history.mkString("\n")}"))
           } else {
             val updated = updatedState.right.get
-            deliveredState(id, updated)
+            deliveredState(ObjectId.generateFromString(id), updated)
             Ok(new RdObject(updated).asJson)
           }
           //          val updatedRDO:  = state.copy(
@@ -143,10 +158,10 @@ class HTTPServer[A](
 object Server {
 //  val CHAT_STATE = AtomicObjectState.initial(List[Any]())
   def fromAddress[C, A](address: String): Server[C, A] = {
-    return new Server[C, A](address, Map[Session[C, A]#Identifier, Client[C,A]](), Map[String, AtomicObjectState[A]]())
+    return new Server[C, A](address, Map[Session[C, A]#Identifier, Client[C,A]](), Map[ObjectId, AtomicObjectState[A]]())
   }
 
-  def getMapOfServer[C, A](server: Server[C, A]): Map[String, AtomicObjectState[A]] ={
+  def getMapOfServer[C, A](server: Server[C, A]): Map[ObjectId, AtomicObjectState[A]] ={
     return server.mapToStates
   }
 }

--- a/src/main/scala/rover/Server.scala
+++ b/src/main/scala/rover/Server.scala
@@ -13,11 +13,14 @@ import rover.rdo.state.AtomicObjectState
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
+
 /**
   * Encapsulating the logic of the server.
   * @param address of the server
   * @param mapToClients, map to clients using as key the access token granted to the client
   * @param mapToStates, map to stable (committed) states of RDOs
+  * @tparam C type of credentials used for sessions (e.g. OAuth2Credentials for OAuth type of auth)
+  * @tparam A type of state of the application (e.g. "Votes" in a poll app, List[Messages] in a chatapp)
 */
 class Server[C, A]( protected val address: String,
                     protected val mapToClients: Map[Session[C, A]#Identifier, Client[C, A]],

--- a/src/main/scala/rover/Server.scala
+++ b/src/main/scala/rover/Server.scala
@@ -6,9 +6,9 @@ import io.circe.syntax._
 import lol.http._
 import lol.json._
 import rover.Client.OAuth2Credentials
-import rover.rdo.client.RdObject
+import rover.rdo.RdObject
 import rover.rdo.conflict.ConflictedState
-import rover.rdo.conflict.provided.AppendIncomingChangesMergeResolve
+import rover.rdo.conflict.resolve.AppendIncomingChangesMergeResolve
 import rover.rdo.state.AtomicObjectState
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/main/scala/rover/Session.scala
+++ b/src/main/scala/rover/Session.scala
@@ -1,7 +1,7 @@
 package rover
 
 import chatapp.ChatServer
-import rover.rdo.RdObject
+import rover.rdo.{ObjectId, RdObject}
 import rover.rdo.state.AtomicObjectState
 
 import scala.concurrent.Future
@@ -12,12 +12,12 @@ class Session[C, A](credentials: C, server: Server[C, A], client: Client[C, A]) 
   type Id = String
   type Identifier = C => Id
 
-  // TODO: Move this to the proper place
-  type ObjectId = Id
+//  // TODO: Move this to the proper place
+//  type ObjectId = Id
 
 
   // TODO: Implement errors
-  def importRDO(objectId: ObjectId): Future[AtomicObjectState[A]] = {
+  def importDummyRDO(objectId: ObjectId): Future[AtomicObjectState[A]] = {
     async{
       if (objectId == "chat"){
         ChatServer.CHAT_STATE.asInstanceOf[AtomicObjectState[A]]
@@ -26,18 +26,14 @@ class Session[C, A](credentials: C, server: Server[C, A], client: Client[C, A]) 
     }
   }
 
-  def importRDOwithState[A](objectId: ObjectId, stateId: String): Future[Unit] = {
-    // TODO: Hacks
-    async {
-      if (objectId == "chat") {
-        val atomicState = server.getAtomicStateWithId(stateId)
-        client.appendedState(stateId, atomicState)
-      }
-//      else null
+  def importRDO(stateId: ObjectId) : Future[AtomicObjectState[A]] = {
+    async{
+      if (server.containsStateId(stateId)) server.getAtomicStateWithId(stateId)
+      else null
     }
   }
   
-  def exportRDOwithState[A](stateId: String): Future[Unit] = {
+  def exportRDOwithState[A](stateId: ObjectId): Future[Unit] = {
     async{
       val atomicState = client.getAtomicStateWithId(stateId)
       server.receivedState(stateId, atomicState)

--- a/src/main/scala/rover/Session.scala
+++ b/src/main/scala/rover/Session.scala
@@ -1,8 +1,8 @@
 package rover
 
 import chatapp.ChatServer
+import rover.rdo.RdObject
 import rover.rdo.state.AtomicObjectState
-import rover.rdo.client.RdObject
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/main/scala/rover/rdo/ObjectId.scala
+++ b/src/main/scala/rover/rdo/ObjectId.scala
@@ -1,4 +1,13 @@
 package rover.rdo
 
+import java.util.UUID
+
 case class ObjectId(asString: String) {
+}
+
+object ObjectId {
+	def generateNew(): ObjectId = {
+		val uuid = UUID.randomUUID()
+		return ObjectId(uuid.toString())
+	}
 }

--- a/src/main/scala/rover/rdo/ObjectId.scala
+++ b/src/main/scala/rover/rdo/ObjectId.scala
@@ -3,11 +3,22 @@ package rover.rdo
 import java.util.UUID
 
 case class ObjectId(asString: String) {
+
+	override def equals(that: Any): Boolean = {
+		that match {
+			case that: ObjectId => return this.asString == that.asString
+			case _ => return false
+		}
+	}
 }
 
 object ObjectId {
 	def generateNew(): ObjectId = {
 		val uuid = UUID.randomUUID()
 		return ObjectId(uuid.toString())
+	}
+
+	def generateFromString(asString: String): ObjectId ={
+		return new ObjectId(asString)
 	}
 }

--- a/src/main/scala/rover/rdo/ObjectId.scala
+++ b/src/main/scala/rover/rdo/ObjectId.scala
@@ -1,0 +1,4 @@
+package rover.rdo
+
+case class ObjectId(asString: String) {
+}

--- a/src/main/scala/rover/rdo/ObjectState.scala
+++ b/src/main/scala/rover/rdo/ObjectState.scala
@@ -1,4 +1,0 @@
-package rover.rdo
-	
-trait ObjectState {
-}

--- a/src/main/scala/rover/rdo/RdObject.scala
+++ b/src/main/scala/rover/rdo/RdObject.scala
@@ -1,0 +1,40 @@
+package rover.rdo
+
+import rover.rdo.state.{AtomicObjectState, RecordedStateModification}
+
+import scala.async.Async.async
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class RdObject[A](val objectId: ObjectId, var state: AtomicObjectState[A]) {
+
+	// same:
+	//FIXME: use hashes instead of Longs/Strings?
+	//TODO: "is up to date" or "version" methods
+
+	protected final def modifyState(op: AtomicObjectState[A]#Op): Unit = {
+		state = state.applyOp(op)
+
+		/** FIXME: Trigger onStateModified? I guess we don't want to make this function async too.\
+		  *     Proposing original division into two sub RDO types:  AutoSyncRdObject & ManualRdObject.\
+		  *     The former works with async methods and refreshes automatically (push), the other is manual
+		  *     (pull). The async one might require raising events for everything.
+		  */
+		//onStateModified(state)
+	}
+
+	// FIXME
+	protected def onStateModified(oldState: AtomicObjectState[A]): Future[Unit] = {
+		async {
+
+		}
+	}
+
+	protected final def immutableState: A = {
+		return state.immutableState
+	}
+
+	override def toString: String = {
+		state.toString
+	}
+}

--- a/src/main/scala/rover/rdo/RdObject.scala
+++ b/src/main/scala/rover/rdo/RdObject.scala
@@ -6,7 +6,7 @@ import scala.async.Async.async
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class RdObject[A](val objectId: ObjectId, var state: AtomicObjectState[A]) {
+class RdObject[A](var state: AtomicObjectState[A]) {
 
 	// same:
 	//FIXME: use hashes instead of Longs/Strings?

--- a/src/main/scala/rover/rdo/conflict/CommonAncestor.scala
+++ b/src/main/scala/rover/rdo/conflict/CommonAncestor.scala
@@ -1,6 +1,6 @@
-package rover.rdo
+package rover.rdo.conflict
 
-import rover.rdo.client.RdObject
+import rover.rdo.RdObject
 import rover.rdo.state.{AtomicObjectState, StateLog}
 
 /**

--- a/src/main/scala/rover/rdo/conflict/CommonAncestor.scala
+++ b/src/main/scala/rover/rdo/conflict/CommonAncestor.scala
@@ -1,6 +1,6 @@
 package rover.rdo.conflict
 
-import rover.rdo.RdObject
+import rover.rdo.{ObjectId, RdObject}
 import rover.rdo.state.{AtomicObjectState, StateLog}
 
 /**
@@ -12,6 +12,11 @@ import rover.rdo.state.{AtomicObjectState, StateLog}
   * @param other Some other RDO
   */
 class CommonAncestor[A](private val one: AtomicObjectState[A], private val other: AtomicObjectState[A]) extends AtomicObjectState[A] { // todo: fixme with a deferred state
+	if (one.objectId != other.objectId) {
+		throw new RuntimeException("Given AtomicObjectStates do not share same objectId. Not allowed to compare the two.")
+	}
+
+	override def objectId: ObjectId = one.objectId // one or other, doesn't matter
 
 	// determine it once and defer all RdObject methods to it
 	def state: AtomicObjectState[A] = {

--- a/src/main/scala/rover/rdo/conflict/CommonAncestor.scala
+++ b/src/main/scala/rover/rdo/conflict/CommonAncestor.scala
@@ -12,11 +12,13 @@ import rover.rdo.state.{AtomicObjectState, StateLog}
   * @param other Some other RDO
   */
 class CommonAncestor[A](private val one: AtomicObjectState[A], private val other: AtomicObjectState[A]) extends AtomicObjectState[A] { // todo: fixme with a deferred state
-	if (one.objectId != other.objectId) {
-		throw new RuntimeException("Given AtomicObjectStates do not share same objectId. Not allowed to compare the two.")
-	}
+	//FIXME: the object id is no longer a field of an atomic state. However, this is not an issue,
+	//		   since the CommonAncestor is invoked on the server side, which has the information for
+	//			 the object id
 
-	override def objectId: ObjectId = one.objectId // one or other, doesn't matter
+//	if (one.objectId != other.objectId) {
+//		throw new RuntimeException("Given AtomicObjectStates do not share same objectId. Not allowed to compare the two.")
+//	}
 
 	// determine it once and defer all RdObject methods to it
 	def state: AtomicObjectState[A] = {

--- a/src/main/scala/rover/rdo/conflict/ConflictedState.scala
+++ b/src/main/scala/rover/rdo/conflict/ConflictedState.scala
@@ -1,7 +1,8 @@
 package rover.rdo.conflict
 
-import rover.rdo.CommonAncestor
-import rover.rdo.client.{DiffWithAncestor, RdObject}
+import rover.rdo.{DiffWithAncestor, RdObject}
+import rover.rdo.client.DiffWithAncestor
+import rover.rdo.rdo.DiffWithAncestor
 import rover.rdo.state.AtomicObjectState
 
 class ConflictedState[A] private (val serverVersion: AtomicObjectState[A], val incomingVersion: AtomicObjectState[A]) {

--- a/src/main/scala/rover/rdo/conflict/ConflictedState.scala
+++ b/src/main/scala/rover/rdo/conflict/ConflictedState.scala
@@ -1,8 +1,6 @@
 package rover.rdo.conflict
 
-import rover.rdo.{DiffWithAncestor, RdObject}
-import rover.rdo.client.DiffWithAncestor
-import rover.rdo.rdo.DiffWithAncestor
+import rover.rdo.RdObject
 import rover.rdo.state.AtomicObjectState
 
 class ConflictedState[A] private (val serverVersion: AtomicObjectState[A], val incomingVersion: AtomicObjectState[A]) {

--- a/src/main/scala/rover/rdo/conflict/DiffWithAncestor.scala
+++ b/src/main/scala/rover/rdo/conflict/DiffWithAncestor.scala
@@ -1,35 +1,6 @@
-package rover.rdo.client
+package rover.rdo.conflict
 
 import rover.rdo.state.{AtomicObjectState, RecordedStateModification}
-
-import scala.async.Async.async
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-
-//FIXME: use hashes instead of Longs/Strings?
-class RdObject[A](var state: AtomicObjectState[A]) {
-
-	// TODO: "is up to date" or "version" methods
-
-	protected final def modifyState(op: AtomicObjectState[A]#Op): Unit = {
-		state = state.applyOp(op)
-//		onStateModified(state)
-	}
-
-	protected def onStateModified(oldState: AtomicObjectState[A]): Future[Unit] = {
-		async {
-
-		}
-	}
-
-	protected final def immutableState: A = {
-		return state.immutableState
-	}
-
-	override def toString: String = {
-		state.toString
-	}
-}
 
 class DiffWithAncestor[A](private val child: AtomicObjectState[A], private val ancestor: AtomicObjectState[A]) {
 
@@ -43,7 +14,7 @@ class DiffWithAncestor[A](private val child: AtomicObjectState[A], private val a
 
 			}
 		}
-		
+
 		throw new RuntimeException("Failed to determine difference with this ancestor")
 	}
 

--- a/src/main/scala/rover/rdo/conflict/resolve/AppendIncomingChangesMergeResolve.scala
+++ b/src/main/scala/rover/rdo/conflict/resolve/AppendIncomingChangesMergeResolve.scala
@@ -1,6 +1,6 @@
 package rover.rdo.conflict.resolve
 
-import rover.rdo.conflict.{ConflictResolutionMechanism, ConflictedState, ResolvedMerge}
+import rover.rdo.conflict.ConflictedState
 
 /**
   * <p>

--- a/src/main/scala/rover/rdo/conflict/resolve/AppendIncomingChangesMergeResolve.scala
+++ b/src/main/scala/rover/rdo/conflict/resolve/AppendIncomingChangesMergeResolve.scala
@@ -1,4 +1,4 @@
-package rover.rdo.conflict.provided
+package rover.rdo.conflict.resolve
 
 import rover.rdo.conflict.{ConflictResolutionMechanism, ConflictedState, ResolvedMerge}
 

--- a/src/main/scala/rover/rdo/conflict/resolve/ConflictResolutionMechanism.scala
+++ b/src/main/scala/rover/rdo/conflict/resolve/ConflictResolutionMechanism.scala
@@ -37,6 +37,6 @@ trait ConflictResolutionMechanism[A] {
 case class ResolvedMerge[A](conflictedState: ConflictedState[A], resultingState: A, implicit val conflictResolutionMechanism: ConflictResolutionMechanism[A]) {
 	def asAtomicObjectState: AtomicObjectState[A] = {
 		val mergeOperationExectured = new MergeOperation[A](conflictedState.serverVersion, conflictedState.incomingVersion, conflictResolutionMechanism)
-		new BasicAtomicObjectState[A](conflictedState.serverVersion.objectId, resultingState, conflictedState.serverVersion.log.appended(mergeOperationExectured))
+		new BasicAtomicObjectState[A](resultingState, conflictedState.serverVersion.log.appended(mergeOperationExectured))
 	}
 }

--- a/src/main/scala/rover/rdo/conflict/resolve/ConflictResolutionMechanism.scala
+++ b/src/main/scala/rover/rdo/conflict/resolve/ConflictResolutionMechanism.scala
@@ -1,5 +1,6 @@
 package rover.rdo.conflict.resolve
 
+import rover.rdo.conflict.ConflictedState
 import rover.rdo.state.{AtomicObjectState, BasicAtomicObjectState, MergeOperation}
 
 /**
@@ -36,6 +37,6 @@ trait ConflictResolutionMechanism[A] {
 case class ResolvedMerge[A](conflictedState: ConflictedState[A], resultingState: A, implicit val conflictResolutionMechanism: ConflictResolutionMechanism[A]) {
 	def asAtomicObjectState: AtomicObjectState[A] = {
 		val mergeOperationExectured = new MergeOperation[A](conflictedState.serverVersion, conflictedState.incomingVersion, conflictResolutionMechanism)
-		new BasicAtomicObjectState[A](resultingState, conflictedState.serverVersion.log.appended(mergeOperationExectured))
+		new BasicAtomicObjectState[A](conflictedState.serverVersion.objectId, resultingState, conflictedState.serverVersion.log.appended(mergeOperationExectured))
 	}
 }

--- a/src/main/scala/rover/rdo/conflict/resolve/ConflictResolutionMechanism.scala
+++ b/src/main/scala/rover/rdo/conflict/resolve/ConflictResolutionMechanism.scala
@@ -1,4 +1,4 @@
-package rover.rdo.conflict
+package rover.rdo.conflict.resolve
 
 import rover.rdo.state.{AtomicObjectState, BasicAtomicObjectState, MergeOperation}
 

--- a/src/main/scala/rover/rdo/state/AtomicObjectState.scala
+++ b/src/main/scala/rover/rdo/state/AtomicObjectState.scala
@@ -1,8 +1,6 @@
 package rover.rdo.state
 
-import rover.rdo.ObjectState
-
-trait AtomicObjectState[A] extends ObjectState {
+trait AtomicObjectState[A] {
 	type Op = A => A
 
 	def immutableState: A

--- a/src/main/scala/rover/rdo/state/StateLog.scala
+++ b/src/main/scala/rover/rdo/state/StateLog.scala
@@ -1,6 +1,7 @@
 package rover.rdo.state
 
-import rover.rdo.conflict.{ConflictResolutionMechanism, ConflictedState}
+import rover.rdo.conflict.ConflictedState
+import rover.rdo.conflict.resolve.ConflictResolutionMechanism
 
 /**
   * Represents a general Logged Operation
@@ -28,7 +29,7 @@ case class StateInitializedLogRecord[A](state: A) extends RecordedStateModificat
 	override def parent: Option[AtomicObjectState[A]] = None
 
 	override def appliedFunction: AtomicObjectState[A] => AtomicObjectState[A] = _ => {
-			new BasicAtomicObjectState[A](state, StateLog.empty.appended(this))
+			AtomicObjectState.initial(state)
 		}
 
 //	override def rebase(newParent: AtomicObjectState[A]): LogRecord[A] = {

--- a/src/main/scala/votingapp/Poll.scala
+++ b/src/main/scala/votingapp/Poll.scala
@@ -1,10 +1,7 @@
 package votingapp
 
-import rover.rdo.{DiffWithAncestor, RdObject}
-import rover.rdo.client.DiffWithAncestor
-import rover.rdo.conflict.ConflictedState
-import rover.rdo.conflict.resolve.AppendIncomingChangesMergeResolve
-import rover.rdo.rdo.DiffWithAncestor
+import rover.rdo.RdObject
+import rover.rdo.conflict.{CommonAncestor, ConflictedState, DiffWithAncestor}
 import rover.rdo.state.AtomicObjectState
 
 

--- a/src/main/scala/votingapp/Poll.scala
+++ b/src/main/scala/votingapp/Poll.scala
@@ -1,9 +1,10 @@
 package votingapp
 
-import rover.rdo.CommonAncestor
-import rover.rdo.client.{DiffWithAncestor, RdObject}
+import rover.rdo.{DiffWithAncestor, RdObject}
+import rover.rdo.client.DiffWithAncestor
 import rover.rdo.conflict.ConflictedState
-import rover.rdo.conflict.provided.AppendIncomingChangesMergeResolve
+import rover.rdo.conflict.resolve.AppendIncomingChangesMergeResolve
+import rover.rdo.rdo.DiffWithAncestor
 import rover.rdo.state.AtomicObjectState
 
 

--- a/src/main/scala/votingapp/PollAppMergeConflictResolutionMechanism.scala
+++ b/src/main/scala/votingapp/PollAppMergeConflictResolutionMechanism.scala
@@ -1,6 +1,6 @@
 package votingapp
 
-import rover.rdo.conflict.provided.AppendIncomingChangesMergeResolve
+import rover.rdo.conflict.resolve.AppendIncomingChangesMergeResolve
 
 class PollAppMergeConflictResolutionMechanism extends AppendIncomingChangesMergeResolve[Votes] {
 	


### PR DESCRIPTION
Refactored objectID; moved functionality to server side. Every new AtomicState at server side is assigned a static objectId, which is then used as a key to map to the state. The state along with the corresponding id  is transferred back and forth between client-server. The id does not change even after an update of a state.